### PR TITLE
Add circle config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,44 @@
+workflows:
+  version: 2
+  main:
+    jobs:
+      - build:
+          filters:
+            tags:
+              only: /.*/
+      - publish:
+          requires:
+            - build
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /.*/
+
+
+version: 2
+jobs:
+  build:
+    docker:
+      - image: cibuilds/chrome-extension:latest
+    steps:
+      - checkout
+      - run:
+          name: "Package Extension"
+          command: git archive -o dist.zip HEAD
+      - persist_to_workspace:
+          root: /root/project
+          paths:
+            - dist.zip
+
+  publish:
+    docker:
+      - image: cibuilds/chrome-extension:latest
+    environment:
+      - APP_ID: lafmglpipgongjmbbjngmboifpaodemk
+    steps:
+      - attach_workspace:
+          at: /root/workspace
+      - run:
+          name: "Publish to the Google Chrome Store"
+          command: publish /root/workspace/dist.zip


### PR DESCRIPTION
Following this guide to get continuous deployment working https://circleci.com/blog/continuously-deploy-a-chrome-extension/

Have already done this for https://github.com/intercom/pr-feed-chrome-extension - its the same config, just a different app id. The app id identifies the extension on the chrome store. It's publicly visible and doesn't change:
![image](https://user-images.githubusercontent.com/9434500/51175165-6b4d0b00-18b1-11e9-943b-5c54a9a69e49.png)


After this, I need to add the project to circle and set up the secrets (`CLIENT_ID`, `CLIENT_SECRET`, `REFRESH_TOKEN`). After that, I'll do a test release before adding the release instructions to the repo
