### PR TITLE
Add widget.request.conditional_formats parser for dashboard

### DIFF
--- a/dashboard-generator.js
+++ b/dashboard-generator.js
@@ -122,7 +122,10 @@ function convertRequests(name, requests) {
     Object.entries(request).forEach(([key, value]) => {
       if (key === "style") {
         result += convertMapping(key, value);
-      } else {
+      } else if (key === "conditional_formats") {
+        result += convertConditionalFormats(key, value);
+      }
+      else {
         result += assignmentString(key, value);
       }
     });
@@ -142,4 +145,17 @@ function convertNestedMappings(mappingName, mapping) {
 
 function singularize(str) {
   return str.replace(/s$/, "");
+}
+
+function convertConditionalFormats(name, conditionalFormats) {
+  let result = "";
+  for (let conditionalFormat of conditionalFormats) {
+    result += name + " {\n";
+
+    Object.entries(conditionalFormat).forEach(([key, value]) => {
+      result += assignmentString(key, value);
+    });
+    result += "}\n";
+  }
+  return result;
 }

--- a/examples/screenboard.json
+++ b/examples/screenboard.json
@@ -10,7 +10,11 @@
           {
             "q": "avg:system.cpu.user{*}",
             "display_type": "line",
-            "style": { "palette": "dog_classic", "line_type": "solid", "line_width": "normal" }
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            }
           }
         ],
         "yaxis": {
@@ -26,26 +30,65 @@
         "time": {},
         "show_legend": false
       },
-      "layout": { "x": 17, "y": 15, "width": 47, "height": 15 }
+      "layout": {
+        "x": 17,
+        "y": 15,
+        "width": 47,
+        "height": 15
+      }
     },
     {
       "id": 6253560944158039,
       "definition": {
         "type": "heatmap",
-        "requests": [{ "q": "avg:system.cpu.user{*}", "style": { "palette": "dog_classic" } }],
+        "requests": [
+          {
+            "q": "avg:system.cpu.user{*}",
+            "style": {
+              "palette": "dog_classic"
+            }
+          }
+        ],
         "title": "Avg of system.cpu.user over *",
         "title_size": "16",
         "title_align": "left",
         "show_legend": false,
         "time": {}
       },
-      "layout": { "x": 78, "y": 7, "width": 47, "height": 15 }
+      "layout": {
+        "x": 78,
+        "y": 7,
+        "width": 47,
+        "height": 15
+      }
     },
     {
       "id": 6015349083435453,
       "definition": {
         "type": "query_value",
-        "requests": [{ "q": "avg:datadog.agent.running{*}", "aggregator": "avg" }],
+        "requests": [
+          {
+            "q": "avg:datadog.agent.running{*}",
+            "aggregator": "avg",
+            "conditional_formats": [
+              {
+                "comparator": "<=",
+                "value": 1,
+                "palette": "white_on_green"
+              },
+              {
+                "comparator": ">",
+                "value": 1,
+                "palette": "white_on_yellow"
+              },
+              {
+                "comparator": ">=",
+                "value": 3,
+                "palette": "white_on_red"
+              }
+            ]
+          }
+        ],
         "title": "Avg of datadog.agent.running over *",
         "title_size": "16",
         "title_align": "left",
@@ -53,7 +96,12 @@
         "autoscale": true,
         "precision": 2
       },
-      "layout": { "x": 8, "y": 35, "width": 47, "height": 15 }
+      "layout": {
+        "x": 8,
+        "y": 35,
+        "width": 47,
+        "height": 15
+      }
     }
   ],
   "template_variables": [],

--- a/examples/screenboard.tf
+++ b/examples/screenboard.tf
@@ -60,6 +60,21 @@ resource "datadog_dashboard" "hi" {
       request {
         q          = "avg:datadog.agent.running{*}"
         aggregator = "avg"
+        conditional_formats {
+          comparator = "<="
+          value      = 1
+          palette    = "white_on_green"
+        }
+        conditional_formats {
+          comparator = ">"
+          value      = 1
+          palette    = "white_on_yellow"
+        }
+        conditional_formats {
+          comparator = ">="
+          value      = 3
+          palette    = "white_on_red"
+        }
       }
       title       = "Avg of datadog.agent.running over *"
       title_size  = "16"

--- a/examples/timeboard.json
+++ b/examples/timeboard.json
@@ -10,7 +10,11 @@
           {
             "q": "avg:system.cpu.user{*}",
             "display_type": "line",
-            "style": { "palette": "dog_classic", "line_type": "solid", "line_width": "normal" }
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            }
           }
         ],
         "yaxis": {
@@ -29,7 +33,29 @@
       "id": 4204614699449750,
       "definition": {
         "type": "query_value",
-        "requests": [{ "q": "avg:datadog.agent.running{*}", "aggregator": "avg" }],
+        "requests": [
+          {
+            "q": "avg:datadog.agent.running{*}",
+            "aggregator": "avg",
+            "conditional_formats": [
+              {
+                "comparator": "<=",
+                "value": 1,
+                "palette": "white_on_green"
+              },
+              {
+                "comparator": ">",
+                "value": 1,
+                "palette": "white_on_yellow"
+              },
+              {
+                "comparator": ">=",
+                "value": 3,
+                "palette": "white_on_red"
+              }
+            ]
+          }
+        ],
         "title": "Avg of datadog.agent.running over *",
         "autoscale": true,
         "precision": 2

--- a/examples/timeboard.tf
+++ b/examples/timeboard.tf
@@ -29,6 +29,21 @@ resource "datadog_dashboard" "hi" {
       request {
         q          = "avg:datadog.agent.running{*}"
         aggregator = "avg"
+        conditional_formats {
+          comparator = "<="
+          value      = 1
+          palette    = "white_on_green"
+        }
+        conditional_formats {
+          comparator = ">"
+          value      = 1
+          palette    = "white_on_yellow"
+        }
+        conditional_formats {
+          comparator = ">="
+          value      = 3
+          palette    = "white_on_red"
+        }
       }
       title     = "Avg of datadog.agent.running over *"
       autoscale = true

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Datadog-to-Terraform Converter",
-  "version": "3.0",
+  "version": "3.0.1",
   "description": "Converts Datadog resource JSON into Terraform alarm code.",
   "manifest_version": 2,
   "browser_action": {


### PR DESCRIPTION
Take a look at the [Contributing Guidelines](../CONTRIBUTING.md) before submitting a PR. Thanks for your help, we appreciate it!

***

# Why?

This plugin is now able to parse new field(s) _widget.request.conditional_formats_.

# How?

I followed the parser for field _request_, without using _singularize_ function for naming (cause this field is plural in terraform).
This parser could be generalised for a field which has a list(object) type, but since this field is the only one using this syntax for now, I've chosen to keep it a  _conditional_formats_ parser.

# UI Changes

Nothing supposes to be changed in UI 😃 