### PR TITLE
Update monitor: use Terraform 0.12+ syntax; remove deprecated silenced option

### DIFF
--- a/examples/monitor.tf
+++ b/examples/monitor.tf
@@ -21,7 +21,7 @@ EOF
   renotify_interval   = "0"
   escalation_message  = ""
   include_tags        = true
-  thresholds {
+  thresholds = {
     critical = 50
   }
 }

--- a/monitor-generator.js
+++ b/monitor-generator.js
@@ -13,9 +13,10 @@ const ALLOWED_OPTIONS_KEYS = [
   "locked",
   "escalation_message",
   "thresholds",
-  "silenced",
   "threshold_windows",
 ];
+
+const DEPRECATED_OPTIONS_KEYS = ["silenced"];
 
 function literalString(value) {
   if (typeof value == "string") {
@@ -45,19 +46,19 @@ export function convertMapping(mappingName, mapping) {
   Object.entries(mapping).forEach(([key, value]) => {
     result += assignmentString(key, value);
   });
-  return `${mappingName} {${result}}\n`;
+  return `${mappingName} = {${result}}\n`;
 }
 
 function convertOptions(options) {
   let result = "";
   Object.entries(options).forEach(([key, value]) => {
     if (ALLOWED_OPTIONS_KEYS.includes(key)) {
-      if (key === "thresholds" || key === "threshold_windows" || key === "silenced") {
+      if (key === "thresholds" || key === "threshold_windows") {
         result += convertMapping(key, value);
       } else {
         result += assignmentString(key, value);
       }
-    } else {
+    } else if (!DEPRECATED_OPTIONS_KEYS.includes(key)) {
       throw `Conversion for "${key}" not found`;
     }
   });

--- a/monitor-generator.js
+++ b/monitor-generator.js
@@ -19,7 +19,7 @@ const ALLOWED_OPTIONS_KEYS = [
 const DEPRECATED_OPTIONS_KEYS = ["silenced"];
 
 function literalString(value) {
-  if (typeof value == "string") {
+  if (typeof value === "string") {
     if (value.includes("\n")) {
       return `<<EOF\n${value}\nEOF`;
     }
@@ -28,7 +28,7 @@ function literalString(value) {
     let result = "[";
     value.forEach((elem, index) => {
       result += literalString(elem);
-      if (index != value.length - 1) result += ",";
+      if (index !== value.length - 1) result += ",";
     });
     return result + "]";
   }
@@ -71,7 +71,7 @@ function convert(key, value) {
     result += assignmentString(key, value);
   } else if (key === "options") {
     result += convertOptions(value);
-  } else if (key == "id") {
+  } else if (key === "id") {
     return result;
   } else {
     throw `Conversion for "${key}" not found`;


### PR DESCRIPTION
# Why?

1. The current code generation for monitor did not generate code compatible with Terraform 0.12+. The issue is in the mapping syntax.

2. The `silenced` option for a monitor is deprecated and will be removed in future versions of Datadog provider (see [https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/monitor#silenced](https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/monitor#silenced)). Therefore, we no longer want to generate it.

# How?

1. Monitor options such as `threshold` and `threshold_windows` now use the following syntax:

```tf
# new
thresholds = {
  critical = 50
}

# old
thresholds {
 critical = 50
}
```

2. The silenced option is now ignored.

# Misc

- Solves, at least partially, https://github.com/laurmurclar/datadog-to-terraform/issues/22. Not sure if anything else needs to be done in that regard.
- Included a bit of boy scouting (in a separate commit) to unify equality operator usage.