### PR TITLE
adding support for widget.definition.metadata

### DIFF
--- a/dashboard-generator.js
+++ b/dashboard-generator.js
@@ -126,9 +126,24 @@ function convertRequests(name, requests) {
         result += convertMapping(key, value);
       } else if (key === "conditional_formats") {
         result += convertConditionalFormats(key, value);
+      } else if (key === "metadata") {
+        result += convertRequestsMetadata(key, value);
       } else {
         result += assignmentString(key, value);
       }
+    });
+    result += "}\n";
+  }
+  return result;
+}
+
+function convertRequestsMetadata(name, metadataArray) {
+  let result = "";
+  for (let metadata of metadataArray) {
+    result += name + " {\n";
+
+    Object.entries(metadata).forEach(([key, value]) => {
+      result += assignmentString(key, value);
     });
     result += "}\n";
   }


### PR DESCRIPTION
# Why?

Datadog Dashboards might have an array of metadata inside `widget.definition`. Right now, this is being translated into

```terraform
metadata: [[Object object]]
```

The correct way is to create many `metadata` elements with their respective content inside `widget.definition`.

# How?
Describe your solution and any technical decisions you made

# UI Changes
Screenshots of the change

## Before

```terraform
metadata: [[Object object]]
```

## After

```terraform
metadata {
  expression = "some_expression"
  alias_name = "some_alias"
}
```

