### PR TITLE
Add better error messaging for failed conversions

### DIFF
--- a/dashboard-converter.js
+++ b/dashboard-converter.js
@@ -1,4 +1,4 @@
-import { assignmentString, blockList, block } from "./utils.js";
+import { assignmentString, block, blockList, convertFromDefinition } from "./utils.js";
 
 const DASHBOARD = {
   layout_type: (v) => assignmentString("layout_type", v),
@@ -10,7 +10,9 @@ const DASHBOARD = {
   notify_list: (v) => assignmentString("notify_list", v),
   template_variables: (v) => blockList(v, "template_variable", assignmentString),
   template_variable_presets: (v) =>
-    blockList(v, "template_variable_preset", (k1, v1) => TEMPLATE_VARIABLE_PRESET[k1](v1)),
+    blockList(v, "template_variable_preset", (k1, v1) =>
+      convertFromDefinition(TEMPLATE_VARIABLE_PRESET, k1, v1)
+    ),
   url: (v) => assignmentString("url", v),
 };
 
@@ -35,7 +37,7 @@ const WIDGET_DEFINTION = {
   text_align: (v) => assignmentString("text_align", v),
   unit: (v) => assignmentString("unit", v),
   custom_links: (v) => blockList(v, "custom_link", assignmentString),
-  requests: (v) => blockList(v, "request", (k1, v1) => REQUEST[k1](v1)),
+  requests: (v) => blockList(v, "request", (k1, v1) => convertFromDefinition(REQUEST, k1, v1)),
   check: (v) => assignmentString("check", v),
   grouping: (v) => assignmentString("grouping", v),
   group: (v) => assignmentString("group", v),
@@ -146,13 +148,13 @@ function convertSort(v) {
 }
 
 function convertWidgets(value) {
-  return blockList(value, "widget", (k, v) => WIDGET[k](v));
+  return blockList(value, "widget", (k1, v1) => convertFromDefinition(WIDGET, k1, v1));
 }
 
 function widgetDefintion(contents) {
   let result = "";
   Object.entries(contents).forEach(([k, v]) => {
-    result += WIDGET_DEFINTION[k](v);
+    result += convertFromDefinition(WIDGET_DEFINTION, k, v);
   });
   let definitionType = contents.type === "slo" ? "service_level_objective" : contents.type;
   return `\n${definitionType}_definition {${result}\n}`;
@@ -161,7 +163,7 @@ function widgetDefintion(contents) {
 export function generateDashboardTerraformCode(resourceName, dashboardData) {
   let result = "";
   Object.entries(dashboardData).forEach(([k, v]) => {
-    result += DASHBOARD[k](v);
+    result += convertFromDefinition(DASHBOARD, k, v);
   });
   return `resource "datadog_dashboard" "${resourceName}" {${result}\n}`;
 }

--- a/dashboard-converter.test.js
+++ b/dashboard-converter.test.js
@@ -1,6 +1,7 @@
 import { generateDashboardTerraformCode } from "./dashboard-converter";
 import screenboardData from "./examples/screenboard.json";
 import timeboardData from "./examples/timeboard.json";
+import badDashboardData from "./examples/bad-dashboard.json";
 
 it("converts screenboards correctly", () => {
   expect(generateDashboardTerraformCode("sb_1", screenboardData)).toMatchSnapshot();
@@ -8,4 +9,10 @@ it("converts screenboards correctly", () => {
 
 it("converts timeboards correctly", () => {
   expect(generateDashboardTerraformCode("tb_1", timeboardData)).toMatchSnapshot();
+});
+
+it("throws an error if a key cannot be converted", () => {
+  expect(() => {
+    generateDashboardTerraformCode("bad_data", badDashboardData);
+  }).toThrow("Can't convert key 'NOT_A_REAL_KEY'");
 });

--- a/examples/bad-dashboard.json
+++ b/examples/bad-dashboard.json
@@ -1,0 +1,4 @@
+{
+  "title": "Laura's Screenboard 7 Sep 2020 13:18",
+  "NOT_A_REAL_KEY": "this is some unknown"
+}

--- a/utils.js
+++ b/utils.js
@@ -36,3 +36,8 @@ export function blockList(array, blockName, contentConverter) {
   });
   return result;
 }
+
+export function convertFromDefinition(definitionSet, k, v) {
+  if (typeof definitionSet[k] !== "function") throw `Can't convert key '${k}'`;
+  return definitionSet[k](v);
+}


### PR DESCRIPTION
Take a look at the [Contributing Guidelines](../CONTRIBUTING.md) before submitting a PR. Thanks for your help, we appreciate it!

***

# Why?
As mentioned in https://github.com/laurmurclar/datadog-to-terraform/pull/37, the error messaging had regressed. 

# How?
Wrapped the conversion lookups in a function, which checks to make sure the conversion function exists in the definition set. If not, it throws an error with a more sensible message, containing the key

# UI Changes
## Before
![image](https://user-images.githubusercontent.com/9434500/107988576-3e0b4380-6fc8-11eb-992b-1a3a651a282f.png)

## After
<img width="523" alt="image" src="https://user-images.githubusercontent.com/9434500/107988564-364b9f00-6fc8-11eb-9ed6-128264bd08af.png">


