### PR TITLE
Fix request conversion for hostmap defintions

### DIFF
--- a/__tests__/__snapshots__/dashboard-converter.test.js.snap
+++ b/__tests__/__snapshots__/dashboard-converter.test.js.snap
@@ -55,8 +55,8 @@ title = \\"Laura's Screenboard 7 Sep 2020 13:18\\"
 description = \\"\\"
 widget {
 widget_layout {
-x = 17
-y = 15
+x = 3
+y = 17
 width = 47
 height = 15
 }
@@ -95,8 +95,8 @@ display_type = \\"error dashed\\"
 }
 widget {
 widget_layout {
-x = 78
-y = 7
+x = 52
+y = 0
 width = 47
 height = 15
 }
@@ -115,8 +115,8 @@ palette = \\"dog_classic\\"
 }
 widget {
 widget_layout {
-x = 8
-y = 35
+x = 3
+y = 33
 width = 47
 height = 15
 }
@@ -165,8 +165,8 @@ max = \\"auto\\"
 }
 widget {
 widget_layout {
-x = 58
-y = 33
+x = 3
+y = 50
 width = 60
 height = 21
 }
@@ -179,6 +179,31 @@ time_windows = [\\"7d\\",\\"month_to_date\\",\\"global_time\\"]
 slo_id = \\"301437ffe3e951a48fdbde5687d90609\\"
 show_error_budget = true
 view_mode = \\"overall\\"
+}
+}
+widget {
+widget_layout {
+x = 52
+y = 17
+width = 47
+height = 22
+}
+hostmap_definition {
+title = \\"\\"
+title_size = \\"16\\"
+title_align = \\"left\\"
+request {
+fill {
+q = \\"avg:system.cpu.user{*} by {host}\\"
+}
+}
+node_type = \\"host\\"
+no_metric_hosts = true
+no_group_hosts = true
+style {
+palette = \\"green_to_orange\\"
+palette_flip = false
+}
 }
 }
 layout_type = \\"free\\"

--- a/__tests__/utils.test.js
+++ b/__tests__/utils.test.js
@@ -1,4 +1,4 @@
-import { assignmentString, map } from "../app/utils";
+import { assignmentString, block, blockList, map } from "../app/utils";
 
 it("assigns strings", () => {
   expect(assignmentString("i", 7)).toBe("\ni = 7");
@@ -10,5 +10,34 @@ it("maps contents", () => {
     "
     a_cool_key = \\"a cool value\\"
     another_key = \\"another value\\""
+  `);
+});
+
+it("converts a block", () => {
+  const contents = { a_cool_key: "a cool value", another_key: "another value" };
+  expect(block("my_block", contents, assignmentString)).toMatchInlineSnapshot(`
+    "
+    my_block {
+    a_cool_key = \\"a cool value\\"
+    another_key = \\"another value\\"
+    }"
+  `);
+});
+
+it("converts a block list", () => {
+  const contents = [
+    { a_cool_key: "a cool value", another_key: "another value" },
+    { a_cool_key: "another cool value", another_key: "another ANOTHER value" },
+  ];
+  expect(blockList(contents, "my_block", assignmentString)).toMatchInlineSnapshot(`
+    "
+    my_block {
+    a_cool_key = \\"a cool value\\"
+    another_key = \\"another value\\"
+    }
+    my_block {
+    a_cool_key = \\"another cool value\\"
+    another_key = \\"another ANOTHER value\\"
+    }"
   `);
 });

--- a/app/dashboard-converter.js
+++ b/app/dashboard-converter.js
@@ -37,7 +37,7 @@ const WIDGET_DEFINTION = {
   text_align: (v) => assignmentString("text_align", v),
   unit: (v) => assignmentString("unit", v),
   custom_links: (v) => blockList(v, "custom_link", assignmentString),
-  requests: (v) => blockList(v, "request", (k1, v1) => convertFromDefinition(REQUEST, k1, v1)),
+  requests: (v) => convertRequests(v),
   check: (v) => assignmentString("check", v),
   grouping: (v) => assignmentString("grouping", v),
   group: (v) => assignmentString("group", v),
@@ -139,6 +139,7 @@ const REQUEST = {
   conditional_formats: (v) => blockList(v, "conditional_formats", assignmentString),
   limit: (v) => assignmentString("limit", v),
   order: (v) => assignmentString("order", v),
+  fill: (v) => block("fill", v, assignmentString),
 };
 
 function convertSort(v) {
@@ -151,13 +152,18 @@ function convertWidgets(value) {
   return blockList(value, "widget", (k1, v1) => convertFromDefinition(WIDGET, k1, v1));
 }
 
+function convertRequests(value) {
+  if (Array.isArray(value)) {
+    return blockList(value, "request", (k, v) => convertFromDefinition(REQUEST, k, v));
+  }
+  return block("request", value, (k, v) => convertFromDefinition(REQUEST, k, v));
+}
+
 function widgetDefintion(contents) {
-  let result = "";
-  Object.entries(contents).forEach(([k, v]) => {
-    result += convertFromDefinition(WIDGET_DEFINTION, k, v);
-  });
   let definitionType = contents.type === "slo" ? "service_level_objective" : contents.type;
-  return `\n${definitionType}_definition {${result}\n}`;
+  return block(`${definitionType}_definition`, contents, (k, v) =>
+    convertFromDefinition(WIDGET_DEFINTION, k, v)
+  );
 }
 
 export function generateDashboardTerraformCode(resourceName, dashboardData) {

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Datadog-to-Terraform Converter",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "Converts Datadog resource JSON into Terraform alarm code.",
   "manifest_version": 2,
   "browser_action": {

--- a/examples/screenboard.json
+++ b/examples/screenboard.json
@@ -4,7 +4,7 @@
   "widgets": [
     {
       "id": 6396751932460267,
-      "layout": { "x": 17, "y": 15, "width": 47, "height": 15 },
+      "layout": { "x": 3, "y": 17, "width": 47, "height": 15 },
       "definition": {
         "title": "",
         "title_size": "16",
@@ -39,7 +39,7 @@
     },
     {
       "id": 6253560944158039,
-      "layout": { "x": 78, "y": 7, "width": 47, "height": 15 },
+      "layout": { "x": 52, "y": 0, "width": 47, "height": 15 },
       "definition": {
         "title": "Avg of system.cpu.user over *",
         "title_size": "16",
@@ -51,7 +51,7 @@
     },
     {
       "id": 6015349083435453,
-      "layout": { "x": 8, "y": 35, "width": 47, "height": 15 },
+      "layout": { "x": 3, "y": 33, "width": 47, "height": 15 },
       "definition": {
         "title": "Avg of datadog.agent.running over *",
         "title_size": "16",
@@ -97,7 +97,7 @@
     },
     {
       "id": 6629276995437899,
-      "layout": { "x": 58, "y": 33, "width": 60, "height": 21 },
+      "layout": { "x": 3, "y": 50, "width": 60, "height": 21 },
       "definition": {
         "title": "SLO: API requests",
         "title_size": "16",
@@ -109,6 +109,21 @@
         "show_error_budget": true,
         "view_mode": "overall",
         "global_time_target": "5"
+      }
+    },
+    {
+      "id": 5597497359474697,
+      "layout": { "x": 52, "y": 17, "width": 47, "height": 22 },
+      "definition": {
+        "title": "",
+        "title_size": "16",
+        "title_align": "left",
+        "type": "hostmap",
+        "requests": { "fill": { "q": "avg:system.cpu.user{*} by {host}" } },
+        "node_type": "host",
+        "no_metric_hosts": true,
+        "no_group_hosts": true,
+        "style": { "palette": "green_to_orange", "palette_flip": false }
       }
     }
   ],


### PR DESCRIPTION
Take a look at the [Contributing Guidelines](../CONTRIBUTING.md) before submitting a PR. Thanks for your help, we appreciate it!

***

# Why?
In `hostmap_definition` blocks, the `requests` can be an object rather than an array, as described in https://github.com/laurmurclar/datadog-to-terraform/issues/43. This code adds support for that. It also adds more test coverage. 

# How?
Use a `block` or `blockList` depending on whether or not `requests` is an array. Also updated the `widgetDefinition` to use `block` to DRY things up a little.