### PR TITLE
fix: add missing monitor attributes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 node_modules/
 .idea
 *.iml
+.history

--- a/__tests__/__snapshots__/monitor-converter.test.js.snap
+++ b/__tests__/__snapshots__/monitor-converter.test.js.snap
@@ -28,6 +28,7 @@ evaluation_delay = 70
 escalation_message = \\"\\"
 no_data_timeframe = 10
 include_tags = true
+on_missing_data = \\"default\\"
 monitor_thresholds {
 critical = 1
 critical_recovery = 0

--- a/__tests__/__snapshots__/monitor-converter.test.js.snap
+++ b/__tests__/__snapshots__/monitor-converter.test.js.snap
@@ -36,6 +36,8 @@ monitor_threshold_windows {
 trigger_window = \\"last_15m\\"
 recovery_window = \\"last_15m\\"
 }
+renotify_statuses = [\\"alert\\"]
 priority = 2
+restricted_roles = [\\"5b647eb8-de36-11ed-aacf-da7ad0900002\\"]
 }"
 `;

--- a/app/monitor-converter.js
+++ b/app/monitor-converter.js
@@ -9,6 +9,7 @@ const MONITOR = {
   id: (_) => "",
   tags: (v) => assignmentString("tags", v),
   priority: (v) => assignmentString("priority", v),
+  restricted_roles: (v) => assignmentString("restricted_roles", v),
 };
 
 const OPTIONS = {
@@ -32,6 +33,7 @@ const OPTIONS = {
   groupby_simple_monitor: (v) => assignmentString("groupby_simple_monitor", v),
   silenced: (_) => "", // 2.23.0 deprecated
   new_group_delay: (v) => assignmentString("new_group_delay", v),
+  renotify_statuses: (v) => assignmentString("renotify_statuses", v),
 };
 
 export function generateTerraformCode(resourceName, monitorData) {

--- a/app/monitor-converter.js
+++ b/app/monitor-converter.js
@@ -34,6 +34,7 @@ const OPTIONS = {
   silenced: (_) => "", // 2.23.0 deprecated
   new_group_delay: (v) => assignmentString("new_group_delay", v),
   renotify_statuses: (v) => assignmentString("renotify_statuses", v),
+  on_missing_data: (v) => assignmentString("on_missing_data", v),
 };
 
 export function generateTerraformCode(resourceName, monitorData) {

--- a/examples/monitor.json
+++ b/examples/monitor.json
@@ -20,6 +20,7 @@
     "escalation_message": "",
     "no_data_timeframe": 10,
     "include_tags": true,
+    "on_missing_data": "default",
     "thresholds": {
       "critical": 1,
       "critical_recovery": 0

--- a/examples/monitor.json
+++ b/examples/monitor.json
@@ -29,12 +29,8 @@
       "trigger_window": "last_15m",
       "recovery_window": "last_15m"
     },
-		"renotify_statuses": [
-			"alert"
-		]
+    "renotify_statuses": ["alert"]
   },
   "priority": 2,
-	"restricted_roles": [
-		"5b647eb8-de36-11ed-aacf-da7ad0900002"
-	]
+  "restricted_roles": ["5b647eb8-de36-11ed-aacf-da7ad0900002"]
 }

--- a/examples/monitor.json
+++ b/examples/monitor.json
@@ -27,7 +27,13 @@
     "threshold_windows": {
       "trigger_window": "last_15m",
       "recovery_window": "last_15m"
-    }
+    },
+		"renotify_statuses": [
+			"alert"
+		]
   },
-  "priority": 2
+  "priority": 2,
+	"restricted_roles": [
+		"5b647eb8-de36-11ed-aacf-da7ad0900002"
+	]
 }


### PR DESCRIPTION
# Why?

renotify_statuses, restricted_roles and on_missing_data attributes are missing at the monitor converter.

Fix #90 

# How?
Add the missing attributes to monitor-converter.js

## Before
can't convert key 'renotify_statuses'
can't convert key 'restricted_roles'
can't convert key 'on_missing_data'

